### PR TITLE
IS-454, add IC3 obs to the HIV visits report

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihmalawi/metadata/CommonMetadata.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/metadata/CommonMetadata.java
@@ -21,6 +21,7 @@ import org.openmrs.LocationAttributeType;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.RelationshipType;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.pihmalawi.metadata.deploy.bundle.concept.IC3ScreeningConcepts;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -108,7 +109,6 @@ public class CommonMetadata extends Metadata {
 	public static final String CONFIRMED = "65590f06-977f-11e1-8993-905e29aff6c1";
 	public static final String TARGETED = "e0821df8-955d-11e7-abc4-cec278b6b50a";
 	public static final String LAB_LOCATION = "6fc0ab50-9492-11e7-abc4-cec278b6b50a";
-	public static final String REASON_NO_RESULT = "656fa450-977f-11e1-8993-905e29aff6c1";
 	public static final String RESULT_MISSING = "e0822140-955d-11e7-abc4-cec278b6b50a";
 	public static final String UNSATISFACTORY_SAMPLE = "656fa55e-977f-11e1-8993-905e29aff6c1";
 
@@ -321,7 +321,7 @@ public class CommonMetadata extends Metadata {
     }
 
     public Concept getReasonNoResultConcept() {
-        return getConcept(REASON_NO_RESULT);
+        return getConcept(IC3ScreeningConcepts.REASON_NO_RESULT);
     }
 
     // Adherence Counselling

--- a/api/src/main/java/org/openmrs/module/pihmalawi/metadata/IC3ScreeningMetadata.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/metadata/IC3ScreeningMetadata.java
@@ -21,6 +21,10 @@ public class IC3ScreeningMetadata extends CommonMetadata {
         return getEncounterType(EncounterTypes.BLOOD_PRESSURE_SCREENING.uuid());
     }
 
+    public EncounterType getClinicianScreeningEncounterType() {
+        return getEncounterType(EncounterTypes.IC3_CLINICIAN_PLAN.uuid());
+    }
+
     public EncounterType getNutritionScreeningEncounterType() {
         return getEncounterType(EncounterTypes.NUTRITION_SCREENING.uuid());
     }

--- a/api/src/main/java/org/openmrs/module/pihmalawi/metadata/deploy/bundle/concept/IC3ScreeningConcepts.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/metadata/deploy/bundle/concept/IC3ScreeningConcepts.java
@@ -43,6 +43,8 @@ public class IC3ScreeningConcepts extends VersionedPihConceptBundle {
 
     public static final String NURSE_STATION_CONCEPT_UUID = "d74065b8-cecf-4ee9-bbba-07bb962e4164";
 
+    public static final String REASON_NO_RESULT = "656fa450-977f-11e1-8993-905e29aff6c1";
+
     @Override
     public int getVersion() {
         return 34;
@@ -223,7 +225,7 @@ public class IC3ScreeningConcepts extends VersionedPihConceptBundle {
                 .answers(noBlood,patientRefused,noMaterials,needsCounseling, unableToProduceSputum, suspectNonPulmonaryTB, materialSupplyOrEquipmentUnavailable)
                 .build());
 
-        Concept noResultReason = MetadataUtils.existing(Concept.class, "656fa450-977f-11e1-8993-905e29aff6c1");
+        Concept noResultReason = MetadataUtils.existing(Concept.class, REASON_NO_RESULT);
         Concept bled           = MetadataUtils.existing(Concept.class, "f792f2f9-9c24-4d6e-98fd-caffa8f2383f");
         Concept vl             = MetadataUtils.existing(Concept.class, "654a7694-977f-11e1-8993-905e29aff6c1");
         Concept ldl            = MetadataUtils.existing(Concept.class, "e97b36a2-16f5-11e6-b6ba-3e1d05defe78");
@@ -681,7 +683,7 @@ public class IC3ScreeningConcepts extends VersionedPihConceptBundle {
                 .mapping(new ConceptMapBuilder("b220aec6-4864-102e-96e9-000c29c2a5d7").type(sameAs).ensureTerm(pih, "2166").build())
                 .build());
 
-        Concept reasonNoResult = install(new ConceptBuilder("656fa450-977f-11e1-8993-905e29aff6c1")
+        Concept reasonNoResult = install(new ConceptBuilder(REASON_NO_RESULT)
                 .datatype(coded)
                 .conceptClass(question)
                 .name("6618934e-977f-11e1-8993-905e29aff6c1", "Reason for no result", Locale.ENGLISH, ConceptNameType.FULLY_SPECIFIED)

--- a/api/src/main/java/org/openmrs/module/pihmalawi/reporting/library/BaseEncounterDataLibrary.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/reporting/library/BaseEncounterDataLibrary.java
@@ -83,6 +83,48 @@ public class BaseEncounterDataLibrary extends BaseDefinitionLibrary<EncounterDat
 		return df.convert(def, df.getObsValueNumericConverter());
 	}
 
+	@DocumentedDefinition(value = "reasonForTestObsReferenceValue")
+	public EncounterDataDefinition getReasonForTestObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getReasonForTestingConcept());
+		return df.convert(def, df.getObsValueCodedNameConverter());
+	}
+
+	@DocumentedDefinition(value = "labLocationObsReferenceValue")
+	public EncounterDataDefinition getLabLocationObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getConcept(hivMetadata.LAB_LOCATION));
+		return df.convert(def, df.getObsValueCodedNameConverter());
+	}
+
+	@DocumentedDefinition(value = "bledObsReferenceValue")
+	public EncounterDataDefinition getBledObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getConcept(hivMetadata.HIV_VIRAL_LOAD_SPECIMEN_COLLECTED));
+		return df.convert(def, df.getObsValueCodedNameConverter());
+	}
+
+	@DocumentedDefinition(value = "vlResultObsReferenceValue")
+	public EncounterDataDefinition getVLResultObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getHivViralLoadConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
+	@DocumentedDefinition(value = "vlLessThanLimitObsReferenceValue")
+	public EncounterDataDefinition getVLLessThanLimitObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getHivLessThanViralLoadConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
+	@DocumentedDefinition(value = "ldlObsReferenceValue")
+	public EncounterDataDefinition getLdlObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getHivLDLConcept());
+		return df.convert(def, df.getObsValueCodedNameConverter());
+	}
+
+	@DocumentedDefinition(value = "reasonNoResultObsReferenceValue")
+	public EncounterDataDefinition getReasonNoResultObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getReasonNoResultConcept());
+		return df.convert(def, df.getObsValueCodedNameConverter());
+	}
+
 	@DocumentedDefinition(value = "ageAtEncounterDateInYears")
 	public EncounterDataDefinition getAgeAtEncounterDateInYears() {
 		return df.convert(getAgeAtEncounterDate(), new AgeConverter(AgeConverter.YEARS));

--- a/api/src/main/java/org/openmrs/module/pihmalawi/reporting/library/BaseEncounterDataLibrary.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/reporting/library/BaseEncounterDataLibrary.java
@@ -47,6 +47,42 @@ public class BaseEncounterDataLibrary extends BaseDefinitionLibrary<EncounterDat
 		return df.convert(def, df.getObsValueDatetimeConverter());
 	}
 
+	@DocumentedDefinition(value = "nextAppointmentDateObsReferenceValue")
+	public EncounterDataDefinition getNextAppointmentDateObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getAppointmentDateConcept());
+		return df.convert(def, df.getObsValueDatetimeConverter());
+	}
+
+	@DocumentedDefinition(value = "weightObsValue")
+	public EncounterDataDefinition getWeightObsValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncounter(hivMetadata.getWeightConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
+	@DocumentedDefinition(value = "weightObsReferenceValue")
+	public EncounterDataDefinition getWeightObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getWeightConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
+	@DocumentedDefinition(value = "heightObsReferenceValue")
+	public EncounterDataDefinition getHeightObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getHeightConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
+	@DocumentedDefinition(value = "systolicBPObsReferenceValue")
+	public EncounterDataDefinition getSystolicBPObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getSystolicBloodPressureConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
+	@DocumentedDefinition(value = "diastolicBPObsReferenceValue")
+	public EncounterDataDefinition getDiastolicBPObsReferenceValue() {
+		EncounterDataDefinition def = df.getSingleObsForEncountersOnSameDate(hivMetadata.getDiastolicBloodPressureConcept());
+		return df.convert(def, df.getObsValueNumericConverter());
+	}
+
 	@DocumentedDefinition(value = "ageAtEncounterDateInYears")
 	public EncounterDataDefinition getAgeAtEncounterDateInYears() {
 		return df.convert(getAgeAtEncounterDate(), new AgeConverter(AgeConverter.YEARS));

--- a/api/src/main/java/org/openmrs/module/pihmalawi/reporting/library/DataFactory.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/reporting/library/DataFactory.java
@@ -70,6 +70,7 @@ import org.openmrs.module.reporting.data.converter.PropertyConverter;
 import org.openmrs.module.reporting.data.encounter.definition.ConvertedEncounterDataDefinition;
 import org.openmrs.module.reporting.data.encounter.definition.EncounterDataDefinition;
 import org.openmrs.module.reporting.data.encounter.definition.ObsForEncounterDataDefinition;
+import org.openmrs.module.reporting.data.encounter.definition.ObsOnSameDateEncounterDataDefinition;
 import org.openmrs.module.reporting.data.patient.definition.ConvertedPatientDataDefinition;
 import org.openmrs.module.reporting.data.patient.definition.EncountersForPatientDataDefinition;
 import org.openmrs.module.reporting.data.patient.definition.PatientDataDefinition;
@@ -380,6 +381,13 @@ public class DataFactory {
 
 	public EncounterDataDefinition getSingleObsForEncounter(Concept concept) {
 		ObsForEncounterDataDefinition def = new ObsForEncounterDataDefinition();
+		def.setQuestion(concept);
+		def.setSingleObs(true);
+		return def;
+	}
+
+	public EncounterDataDefinition getSingleObsForEncountersOnSameDate(Concept concept) {
+		ObsOnSameDateEncounterDataDefinition def = new ObsOnSameDateEncounterDataDefinition();
 		def.setQuestion(concept);
 		def.setSingleObs(true);
 		return def;

--- a/api/src/main/java/org/openmrs/module/pihmalawi/reporting/reports/HivVisitsReport.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/reporting/reports/HivVisitsReport.java
@@ -130,6 +130,12 @@ public class HivVisitsReport extends ApzuDataExportManager {
 		dsd.addColumn("District", basePatientData.getDistrict(), "");
 		dsd.addColumn("T/A", basePatientData.getTraditionalAuthority(), "");
 		dsd.addColumn("Village", basePatientData.getVillage(), "");
+		dsd.addColumn("IC3_WEIGHT", baseEncounterData.getWeightObsReferenceValue(), "");
+		dsd.addColumn("IC3_HEIGHT", baseEncounterData.getWeightObsReferenceValue(), "");
+		dsd.addColumn("IC3_SYSTOLIC_BP", baseEncounterData.getSystolicBPObsReferenceValue(), "");
+		dsd.addColumn("IC3_DIASTOLIC_BP", baseEncounterData.getDiastolicBPObsReferenceValue(), "");
+		dsd.addColumn("IC3_NEXT_APPOINTMENT_DATE", baseEncounterData.getNextAppointmentDateObsReferenceValue(), "");
+
 
 		rd.addDataSetDefinition(key, Mapped.mapStraightThrough(dsd));
 	}

--- a/api/src/main/java/org/openmrs/module/pihmalawi/reporting/reports/HivVisitsReport.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/reporting/reports/HivVisitsReport.java
@@ -24,6 +24,7 @@ import org.openmrs.module.reporting.common.ObjectUtil;
 import org.openmrs.module.reporting.data.encounter.library.BuiltInEncounterDataLibrary;
 import org.openmrs.module.reporting.data.patient.library.BuiltInPatientDataLibrary;
 import org.openmrs.module.reporting.dataset.definition.EncounterAndObsDataSetDefinition;
+import org.openmrs.module.reporting.dataset.definition.EncounterDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.query.encounter.definition.BasicEncounterQuery;
@@ -99,12 +100,32 @@ public class HivVisitsReport extends ApzuDataExportManager {
 		rd.setParameters(getParameters());
 		addDataSet(rd, "art_initial", metadata.getArtInitialEncounterType(), metadata.getArvNumberIdentifierType());
 		addDataSet(rd, "art_followup", metadata.getArtFollowupEncounterType(), metadata.getArvNumberIdentifierType());
-		addDataSet(rd, "viral_load", screeningMetadata.getVLScreeningEncounterType(), metadata.getArvNumberIdentifierType());
+		addViralLoadDataSet(rd, "viral_load",  metadata.getArvNumberIdentifierType());
 		addDataSet(rd, "part_initial", metadata.getPreArtInitialEncounterType(), metadata.getHccNumberIdentifierType());
 		addDataSet(rd, "part_followup", metadata.getPreArtFollowupEncounterType(), metadata.getHccNumberIdentifierType());
 		addDataSet(rd, "exposed_child_initial", metadata.getExposedChildInitialEncounterType(), metadata.getHccNumberIdentifierType());
 		addDataSet(rd, "exposed_child_followup", metadata.getExposedChildFollowupEncounterType(), metadata.getHccNumberIdentifierType());
 		return rd;
+	}
+
+	protected void addGeneralColumns(EncounterDataSetDefinition encounterDataSetDefinition, PatientIdentifierType identifierType) {
+		if (encounterDataSetDefinition != null) {
+			encounterDataSetDefinition.addColumn("ENCOUNTER_ID", builtInEncounterData.getEncounterId(), "");
+			encounterDataSetDefinition.addColumn("ENCOUNTER_DATETIME", builtInEncounterData.getEncounterDatetime(), "");
+			encounterDataSetDefinition.addColumn("LOCATION", builtInEncounterData.getLocationName(), "");
+			encounterDataSetDefinition.addColumn("INTERNAL_PATIENT_ID", builtInEncounterData.getPatientId(), "");
+			encounterDataSetDefinition.addColumn(identifierType.getName(), df.getAllIdentifiersOfType(identifierType, df.getIdentifierCollectionConverter()), "");
+			encounterDataSetDefinition.addColumn("Birthdate", basePatientData.getBirthdate(), "");
+			encounterDataSetDefinition.addColumn("Age at encounter (yr)", baseEncounterData.getAgeAtEncounterDateInYears(), "");
+			encounterDataSetDefinition.addColumn("Age at encounter (mth)", baseEncounterData.getAgeAtEncounterDateInMonths(), "");
+			encounterDataSetDefinition.addColumn("M/F", builtInPatientData.getGender(), "");
+			encounterDataSetDefinition.addColumn("District", basePatientData.getDistrict(), "");
+			encounterDataSetDefinition.addColumn("T/A", basePatientData.getTraditionalAuthority(), "");
+			encounterDataSetDefinition.addColumn("Village", basePatientData.getVillage(), "");
+			encounterDataSetDefinition.addColumn("IC3_WEIGHT", baseEncounterData.getWeightObsReferenceValue(), "");
+			encounterDataSetDefinition.addColumn("IC3_HEIGHT", baseEncounterData.getWeightObsReferenceValue(), "");
+		}
+
 	}
 
 	protected void addDataSet(ReportDefinition rd, String key, EncounterType encounterType, PatientIdentifierType identifierType) {
@@ -118,24 +139,37 @@ public class HivVisitsReport extends ApzuDataExportManager {
 		MappedParametersEncounterQuery q = new MappedParametersEncounterQuery(rowFilter, ObjectUtil.toMap("onOrAfter=startDate,onOrBefore=endDate"));
 		dsd.addRowFilter(Mapped.mapStraightThrough(q));
 
-		dsd.addColumn("ENCOUNTER_ID", builtInEncounterData.getEncounterId(), "");
-		dsd.addColumn("ENCOUNTER_DATETIME", builtInEncounterData.getEncounterDatetime(), "");
-		dsd.addColumn("LOCATION", builtInEncounterData.getLocationName(), "");
-		dsd.addColumn("INTERNAL_PATIENT_ID", builtInEncounterData.getPatientId(), "");
-		dsd.addColumn(identifierType.getName(), df.getAllIdentifiersOfType(identifierType, df.getIdentifierCollectionConverter()), "");
-		dsd.addColumn("Birthdate", basePatientData.getBirthdate(), "");
-		dsd.addColumn("Age at encounter (yr)", baseEncounterData.getAgeAtEncounterDateInYears(), "");
-		dsd.addColumn("Age at encounter (mth)", baseEncounterData.getAgeAtEncounterDateInMonths(), "");
-		dsd.addColumn("M/F", builtInPatientData.getGender(), "");
-		dsd.addColumn("District", basePatientData.getDistrict(), "");
-		dsd.addColumn("T/A", basePatientData.getTraditionalAuthority(), "");
-		dsd.addColumn("Village", basePatientData.getVillage(), "");
-		dsd.addColumn("IC3_WEIGHT", baseEncounterData.getWeightObsReferenceValue(), "");
-		dsd.addColumn("IC3_HEIGHT", baseEncounterData.getWeightObsReferenceValue(), "");
+		addGeneralColumns(dsd, identifierType);
 		dsd.addColumn("IC3_SYSTOLIC_BP", baseEncounterData.getSystolicBPObsReferenceValue(), "");
 		dsd.addColumn("IC3_DIASTOLIC_BP", baseEncounterData.getDiastolicBPObsReferenceValue(), "");
 		dsd.addColumn("IC3_NEXT_APPOINTMENT_DATE", baseEncounterData.getNextAppointmentDateObsReferenceValue(), "");
 
+		rd.addDataSetDefinition(key, Mapped.mapStraightThrough(dsd));
+	}
+
+	protected void addViralLoadDataSet(ReportDefinition rd, String key, PatientIdentifierType identifierType) {
+		EncounterDataSetDefinition dsd = new EncounterDataSetDefinition();
+		dsd.setParameters(getParameters());
+
+		BasicEncounterQuery rowFilter = new BasicEncounterQuery();
+		rowFilter.addEncounterType(metadata.getArtFollowupEncounterType());
+		rowFilter.addEncounterType(screeningMetadata.getVLScreeningEncounterType());
+		rowFilter.addParameter(new Parameter("onOrAfter", "On Or After", Date.class));
+		rowFilter.addParameter(new Parameter("onOrBefore", "On Or Before", Date.class));
+		MappedParametersEncounterQuery q = new MappedParametersEncounterQuery(rowFilter, ObjectUtil.toMap("onOrAfter=startDate,onOrBefore=endDate"));
+		dsd.addRowFilter(Mapped.mapStraightThrough(q));
+
+		addGeneralColumns(dsd, identifierType);
+		dsd.addColumn("ENCOUNTER_TYPE", builtInEncounterData.getEncounterTypeName(), "");
+		dsd.addColumn("REASON_FOR_TEST", baseEncounterData.getReasonForTestObsReferenceValue(), "");
+		dsd.addColumn("LAB_LOCATION", baseEncounterData.getLabLocationObsReferenceValue(), "");
+		dsd.addColumn("BLED", baseEncounterData.getBledObsReferenceValue(), "");
+		dsd.addColumn("VL_RESULT", baseEncounterData.getVLResultObsReferenceValue(), "");
+		dsd.addColumn("VL_LESS_THAN_LIMIT", baseEncounterData.getVLLessThanLimitObsReferenceValue(), "");
+		dsd.addColumn("LDL", baseEncounterData.getLdlObsReferenceValue(), "");
+		dsd.addColumn("REASON_NO_SAMPLE", baseEncounterData.getReasonNoResultObsReferenceValue(), "");
+
+		dsd.addColumn("IC3_NEXT_APPOINTMENT_DATE", baseEncounterData.getNextAppointmentDateObsReferenceValue(), "");
 
 		rd.addDataSetDefinition(key, Mapped.mapStraightThrough(dsd));
 	}

--- a/api/src/test/java/org/openmrs/module/pihmalawi/reporting/definition/data/evaluator/HivVisitsDataEvaluatorTest.java
+++ b/api/src/test/java/org/openmrs/module/pihmalawi/reporting/definition/data/evaluator/HivVisitsDataEvaluatorTest.java
@@ -1,0 +1,169 @@
+package org.openmrs.module.pihmalawi.reporting.definition.data.evaluator;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.*;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.pihmalawi.BaseMalawiTest;
+import org.openmrs.module.pihmalawi.metadata.HivMetadata;
+import org.openmrs.module.pihmalawi.metadata.IC3ScreeningMetadata;
+import org.openmrs.module.pihmalawi.reporting.library.BaseEncounterDataLibrary;
+import org.openmrs.module.reporting.common.DateUtil;
+import org.openmrs.module.reporting.common.ObjectUtil;
+import org.openmrs.module.reporting.data.converter.DateConverter;
+import org.openmrs.module.reporting.data.encounter.definition.EncounterDataDefinition;
+import org.openmrs.module.reporting.data.encounter.definition.EncounterDatetimeDataDefinition;
+import org.openmrs.module.reporting.data.encounter.definition.EncounterIdDataDefinition;
+import org.openmrs.module.reporting.data.encounter.library.BuiltInEncounterDataLibrary;
+import org.openmrs.module.reporting.data.encounter.service.EncounterDataService;
+import org.openmrs.module.reporting.data.patient.definition.PatientIdDataDefinition;
+import org.openmrs.module.reporting.data.person.definition.BirthdateDataDefinition;
+import org.openmrs.module.reporting.dataset.DataSet;
+import org.openmrs.module.reporting.dataset.DataSetRow;
+import org.openmrs.module.reporting.dataset.DataSetRowList;
+import org.openmrs.module.reporting.dataset.SimpleDataSet;
+import org.openmrs.module.reporting.dataset.definition.EncounterAndObsDataSetDefinition;
+import org.openmrs.module.reporting.dataset.definition.EncounterDataSetDefinition;
+import org.openmrs.module.reporting.dataset.definition.service.DataSetDefinitionService;
+import org.openmrs.module.reporting.evaluation.EvaluationContext;
+import org.openmrs.module.reporting.evaluation.context.EncounterEvaluationContext;
+import org.openmrs.module.reporting.evaluation.parameter.Mapped;
+import org.openmrs.module.reporting.evaluation.parameter.Parameter;
+import org.openmrs.module.reporting.query.encounter.EncounterIdSet;
+import org.openmrs.test.SkipBaseSetup;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+
+@SkipBaseSetup
+public class HivVisitsDataEvaluatorTest extends BaseMalawiTest {
+
+    @Autowired
+    HivMetadata hivMetadata;
+
+    @Autowired
+    private IC3ScreeningMetadata screeningMetadata;
+
+    @Autowired
+    private BuiltInEncounterDataLibrary builtInEncounterData;
+
+    @Autowired
+    BaseEncounterDataLibrary baseEncounterData;
+
+    protected Encounter createVisitEncounter(Patient patient, EncounterType encounterType, Concept regimen, Number height, Number weight, Number systolicBP, Number diastolicBP, Date nextAppointmentDate, Date followupDate) {
+        Encounter e = createEncounter(patient, encounterType, followupDate).save();
+        if (regimen != null) {
+            createObs(e, hivMetadata.getArvDrugsReceivedConcept(), regimen).save();
+        }
+        if (height !=null) {
+            createObs(e, hivMetadata.getHeightConcept(), height).save();
+        }
+        if (weight != null) {
+            createObs(e, hivMetadata.getWeightConcept(), weight).save();
+        }
+        if (systolicBP != null) {
+            createObs(e, hivMetadata.getSystolicBloodPressureConcept(), systolicBP).save();
+        }
+        if (diastolicBP != null) {
+            createObs(e, hivMetadata.getDiastolicBloodPressureConcept(), diastolicBP).save();
+        }
+        if (nextAppointmentDate != null) {
+            createObs(e, hivMetadata.getAppointmentDateConcept(), nextAppointmentDate).save();
+        }
+
+        return e;
+    }
+
+    @Test
+    public void shouldTestHivVisitsHistory() throws Exception {
+
+        EncounterType artFollowupEncounterType = hivMetadata.getArtFollowupEncounterType();
+        EncounterType nutritionScreeningEncounterType = screeningMetadata.getNutritionScreeningEncounterType();
+        EncounterType bloodPressureScreeningEncounterType = screeningMetadata.getBloodPressureScreeningEncounterType();
+        EncounterType clinicianScreeningEncounterType = screeningMetadata.getClinicianScreeningEncounterType();
+
+        EncounterEvaluationContext context = new EncounterEvaluationContext();
+
+        Cohort baseCohort = new Cohort();
+        Patient testPatient = createPatient().save();
+        baseCohort.addMember(testPatient.getPatientId());
+        context.setBaseCohort(baseCohort);
+
+        Date d1 = DateUtil.getDateTime(2010, 4, 5);
+        Concept reg1 = hivMetadata.getArvRegimen2aConcept();
+        Encounter artInitial = createEncounter(testPatient, hivMetadata.getArtInitialEncounterType(), d1).save();
+        Obs regChange1 = createObs(artInitial, hivMetadata.getArvDrugsChange1Concept(), reg1).save();
+        Obs regDate1 = createObs(artInitial, hivMetadata.getDateOfStartingFirstLineArvsConcept(), d1).save();
+
+        Date d2 = DateUtil.getDateTime(2013, 10, 7);
+        Concept reg2 = hivMetadata.getArvRegimen4aConcept();
+        Encounter e1 = createVisitEncounter(testPatient, artFollowupEncounterType, reg2, null, null, null, null, DateUtil.getDateTime(2013, 11, 7), d2);
+        Encounter e1_nutrition = createVisitEncounter(testPatient, nutritionScreeningEncounterType, null, 169, 60, null, null, null, d2);
+        Encounter e1_bp = createVisitEncounter(testPatient, bloodPressureScreeningEncounterType, null, null, null, 160, 60, null, d2);
+
+        Date d3 = DateUtil.getDateTime(2017, 11, 29);
+        Encounter e2 = createVisitEncounter(testPatient, artFollowupEncounterType, reg2, 170, 63, null, null, DateUtil.getDateTime(2017, 12, 28), d3);
+
+        Date d4 = DateUtil.getDateTime(2018, 2, 10);
+        Encounter e3 = createVisitEncounter(testPatient, artFollowupEncounterType, reg2, 170, 62, null, null, DateUtil.getDateTime(2018, 3, 10), d4);
+
+        Date d5 = DateUtil.getDateTime(2018, 6, 17);
+        Concept reg3 = hivMetadata.getArvRegimen6aConcept();
+        Encounter e4 = createVisitEncounter(testPatient, artFollowupEncounterType, reg3, 170, 65, null, null, DateUtil.getDateTime(2018, 7, 17), d5);
+
+        Date d6 = DateUtil.getDateTime(2018, 8, 11);
+        Date nextAppointmentDate = DateUtil.getDateTime(2018, 9, 11);
+        Encounter e5 = createVisitEncounter(testPatient, artFollowupEncounterType, reg3, null, null, null, null, null, d6);
+        Encounter e5_nutrition = createVisitEncounter(testPatient, nutritionScreeningEncounterType, null, 170, 66, null, null, null, d6);
+        Encounter e5_bp = createVisitEncounter(testPatient, bloodPressureScreeningEncounterType, null, null, null, 158, 47, null, d6);
+        Encounter e5_clinician_plan = createVisitEncounter(testPatient, clinicianScreeningEncounterType, null, null, null, null, null, nextAppointmentDate, d6);
+
+        EncounterAndObsDataSetDefinition dsd = new EncounterAndObsDataSetDefinition();
+
+        dsd.addColumn("ENCOUNTER_ID", new EncounterIdDataDefinition(), null);	// Test a basic encounter data item
+        dsd.addColumn("ENCOUNTER_TYPE", builtInEncounterData.getEncounterTypeName(), null);
+        dsd.addColumn("EMR_ID", new PatientIdDataDefinition(), null); 			// Test a basic patient data item
+        dsd.addColumn("BIRTHDATE", new BirthdateDataDefinition(), null); 		// Test a basic person data item
+        dsd.addColumn("ENCOUNTER_DATE", new EncounterDatetimeDataDefinition(), null, new DateConverter("dd/MMM/yyyy"));  // Test a column with a converter
+
+        EncounterDataDefinition nextAppointmentDateDefinition = baseEncounterData.getNextAppointmentDateObsReferenceValue();
+        dsd.addColumn("IC3_NEXT_APPOINTMENT_DATE", nextAppointmentDateDefinition, ObjectUtil.toString(Mapped.straightThroughMappings(nextAppointmentDateDefinition), "=", ","));
+
+        EncounterDataDefinition weightObsDef = baseEncounterData.getWeightObsReferenceValue();
+        dsd.addColumn("IC3_WEIGHT", weightObsDef, ObjectUtil.toString(Mapped.straightThroughMappings(weightObsDef), "=", ","));
+        dsd.addColumn("IC3_SYSTOLIC_BP", baseEncounterData.getSystolicBPObsReferenceValue(), ObjectUtil.toString(Mapped.straightThroughMappings(baseEncounterData.getSystolicBPObsReferenceValue()), "=", ","));
+        dsd.addColumn("IC3_DIASTOLIC_BP", baseEncounterData.getDiastolicBPObsReferenceValue(), ObjectUtil.toString(Mapped.straightThroughMappings(baseEncounterData.getDiastolicBPObsReferenceValue()), "=", ","));
+
+        context.setBaseEncounters(new EncounterIdSet(e1.getId(), e2.getId(), e3.getId(), e4.getId(), e5.getId() ));
+
+        DataSet dataset = Context.getService(DataSetDefinitionService.class).evaluate(dsd, context);
+        DataSetRowList rows = ((SimpleDataSet) dataset).getRows();
+        Assert.assertEquals(rows.size(), context.getBaseEncounters().getSize());
+
+        DataSetRow rowByField = getRowByField(rows, "ENCOUNTER_ID", e5.getId().toString());
+        Assert.assertNotNull(rowByField);
+        // retrieves the Weight Obs entered via the Nutrition encounter which was not part of the BaseEncounters set
+        Assert.assertEquals( Double.compare((Double) rowByField.getColumnValue("IC3_WEIGHT"), 66), 0);
+
+        // retrieves the Systolic BP Obs entered via the IC3 BP encounter which was not part of the BaseEncounters set
+        Assert.assertEquals( Double.compare((Double) rowByField.getColumnValue("IC3_SYSTOLIC_BP"), 158), 0);
+
+        Assert.assertEquals( rowByField.getColumnValue("IC3_NEXT_APPOINTMENT_DATE"), nextAppointmentDate );
+
+    }
+
+    DataSetRow getRowByField(DataSetRowList rows, String fieldName, String fieldValue) {
+        DataSetRow row = null;
+
+        if (rows != null && rows.size() > 0 ) {
+            for (DataSetRow dataSetRow : rows) {
+                Object encounter_id = dataSetRow.getColumnValue(fieldName);
+                if (StringUtils.equals(encounter_id.toString(), fieldValue)) {
+                    return dataSetRow;
+                }
+            }
+        }
+        return row;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <metadatasharingVersion>1.2.2</metadatasharingVersion>
         <namephoneticsVersion>1.5</namephoneticsVersion>
         <providermanagementVersion>2.10.0</providermanagementVersion>
-        <reportingVersion>1.13.0</reportingVersion>
+        <reportingVersion>1.18.0-SNAPSHOT</reportingVersion>
         <reportinguiVersion>1.2</reportinguiVersion>
         <reportingrestVersion>1.7.0</reportingrestVersion>
         <reportingcompatibilityVersion>1.5.8</reportingcompatibilityVersion>


### PR DESCRIPTION
Hi @mseaton and @mogoodrich , here is my first attempt to include on_same_day Obs across encounters in the HIV Visits Report. For now, I have added IC3_WEIGHT, IC3_HEIGHT, IC3_SYSTOLIC_BP, IC3_DIASTOLIC_BP and IC3_NEXT_APPOINTMENT_DATE as separate columns on each of the Excel sheets. This was the easiest way to display those cross encounters obs without the need to redefine each individual field from the ART_FOLLOW_UP encounter. I continue to rely on EncounterAndObsDataSetDefinition to dynamically retrieve each obs in each encounter. The disadvantage of this approach is that we have now two weight columns, the IC3_WEIGHT that looks for weight obs across all encounters on a given day, and WEIGHT_(KG) column that only display a value if weight was captured using the ART_FOLLOWUP mastercard. If you guys think that this is too confusing, I am going to work next on re-defining column by column all the fields in the ART_FOLLOW_UP encounter. Please let me know what you think.
@mogoodrich : It would be good to know what the team Neno thinks about this updated report? Are they still using those HIV Visits, NCD Visits reports? Thanks!