### PR TITLE
MLW-1548: Update Likuni Phala field to accept numeric values

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihmalawi/metadata/deploy/bundle/concept/MasterCardConcepts.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/metadata/deploy/bundle/concept/MasterCardConcepts.java
@@ -173,7 +173,7 @@ public class MasterCardConcepts extends VersionedPihConceptBundle {
 
     @Override
     public int getVersion() {
-        return 23;
+        return 24;
     }
 
     @Override
@@ -1549,6 +1549,12 @@ public class MasterCardConcepts extends VersionedPihConceptBundle {
                 .datatype(date)
                 .conceptClass(question)
                 .name("f06433e4-73f0-4977-9884-df1108559def", "Date of Urine Lam", Locale.ENGLISH, ConceptNameType.FULLY_SPECIFIED)
+                .build());
+
+        Concept likuniPhala = install(new ConceptBuilder("32b3ecd3-a166-47d4-b321-0f90be8391b8")
+                .datatype(numeric)
+                .conceptClass(misc)
+                .name("c4d07f2c-8476-43e1-b3d6-6ab63708f6cf", "Likuni Phala given to patient(Kg)", Locale.ENGLISH, ConceptNameType.FULLY_SPECIFIED)
                 .build());
     }
 }

--- a/omod/src/main/webapp/resources/htmlforms/art_mastercard.xml
+++ b/omod/src/main/webapp/resources/htmlforms/art_mastercard.xml
@@ -206,10 +206,12 @@
                             <td>
                                 <obs conceptId="$tbStatus" style="radio" answerConceptIds="$tbnever,$tbLast,$tbCurr" answerLabels="Never,Last,Curr" />
                             </td>
-                            <td>Preg/Breastf</td>
-                            <td>
-                                <obs conceptId="$pregnantLactating" style="radio" answerConceptIds="$noAnswer,$currentlyPregnant,$currentlyLactating" answerLabels="No,Preg,Bf" />
-                            </td>
+                            <includeIf velocityTest="$patient.gender == 'F'">
+                                <td>Preg/Breastf</td>
+                                <td>
+                                    <obs conceptId="$pregnantLactating" style="radio" answerConceptIds="$noAnswer,$currentlyPregnant,$currentlyLactating" answerLabels="No,Preg,Bf" />
+                                </td>
+                            </includeIf>
                         </tr>
 
 

--- a/omod/src/main/webapp/resources/htmlforms/nutrition_adults_visit.xml
+++ b/omod/src/main/webapp/resources/htmlforms/nutrition_adults_visit.xml
@@ -9,10 +9,10 @@
     <macro key="bmi" value="655d615a-977f-11e1-8993-905e29aff6c1"/>
     <macro key="nextAppt" value="6569cbd4-977f-11e1-8993-905e29aff6c1"/>
     <macro key="nenoLocations" expression="fn.globalProperty('pihmalawi.systemLocationsTag')"/>
-    <macro key="likuniPhala" value="656225e6-977f-11e1-8993-905e29aff6c1"/>
     <macro key="typeOfFeedSet" value="38725750-df54-477a-a9b0-42527f94b709"/>
     <macro key="givenName" value="6570f9ea-977f-11e1-8993-905e29aff6c1"/>
     <macro key="clinicalImpressions" value="655928e2-977f-11e1-8993-905e29aff6c1"/>
+    <macro key="foodLikuni" value="32b3ecd3-a166-47d4-b321-0f90be8391b8"/>
 </macros>
 
 <!-- Flowsheet table view -->
@@ -33,8 +33,7 @@
                 <td style="padding: 1px" rowspan="2">Weight</td>
                 <td style="padding: 1px" rowspan="2">Height</td>
                 <td style="padding: 1px" rowspan="2">BMI</td>
-                <td style="padding: 1px" rowspan="2">Likuni Phala (Kgs)</td>
-
+                <td style="padding: 1px" rowspan="2">Likuni Phala</td>
 
             </tr>
         </thead>
@@ -55,16 +54,10 @@
                     <!-- BMI-->
                     <obs conceptId="$bmi" />
                 </td>
-
                 <td style="padding: 1px;">
-                    <!-- food - likuni phala -->
-                    <obsgroup groupingConceptId="$typeOfFeedSet">
-                        <obs conceptId="$likuniPhala"
-                             answerConceptIds="$yesAnswer,$noAnswer"
-                             answerLabels="Yes,No" style="radio" />
-                    </obsgroup>
+                    <!-- BMI-->
+                    <obs conceptId="$foodLikuni" />
                 </td>
-
                 <td style="padding: 1px;" >
                     <!-- Next appointment -->
                     <obs conceptId="$nextAppt" id="appointmentDate" allowFutureDates="true" allowOverride="true"/>
@@ -126,15 +119,10 @@
                     <obs conceptId="$bmi"/>
                 </td>
             </tr>
-
             <tr>
-                <th>Likuni Phala (Kgs)</th>
-                <td style="padding: 1px;">
-                    <obsgroup groupingConceptId="$typeOfFeedSet">
-                        <obs conceptId="$likuniPhala"
-                             answerConceptIds="$yesAnswer,$noAnswer"
-                             answerLabels="Yes,No" style="radio" />
-                    </obsgroup>
+                <th>Food Likuni</th>
+                <td>
+                    <obs conceptId="$foodLikuni"/>
                 </td>
             </tr>
             <tr>

--- a/omod/src/main/webapp/resources/htmlforms/nutrition_adults_visit.xml
+++ b/omod/src/main/webapp/resources/htmlforms/nutrition_adults_visit.xml
@@ -33,7 +33,7 @@
                 <td style="padding: 1px" rowspan="2">Weight</td>
                 <td style="padding: 1px" rowspan="2">Height</td>
                 <td style="padding: 1px" rowspan="2">BMI</td>
-                <td style="padding: 1px" rowspan="2">Likuni Phala</td>
+                <td style="padding: 1px" rowspan="2">Likuni Phala(Kgs)</td>
 
             </tr>
         </thead>

--- a/omod/src/main/webapp/resources/htmlforms/teen_club_visit.xml
+++ b/omod/src/main/webapp/resources/htmlforms/teen_club_visit.xml
@@ -24,6 +24,7 @@
         <macro key="tbConfirmedTx" value="65770ca4-977f-11e1-8993-905e29aff6c1" />
         <macro key="nextAppt" value="6569cbd4-977f-11e1-8993-905e29aff6c1"/>
         <macro key="formEncTypeUuid" value="664b8650-977f-11e1-8993-905e29aff6c1"/>
+        <macro key="bmi" value="655d615a-977f-11e1-8993-905e29aff6c1"/>
         <macro key="nenoLocations" expression="fn.globalProperty('pihmalawi.systemLocationsTag')"/>
     </macros>
 
@@ -36,7 +37,7 @@
                     <td style="padding: 1px;" >Visit Date</td>
                     <td style="padding: 1px">Hgt</td>
                     <td style="padding: 1px">Wt</td>
-                    <td rowspan="2">Pregnant/<br/>Breastfeed.</td>
+                    <td rowspan="2">MUAC/<br/>BMI</td>
                     <td style="padding: 1px" colspan="2">TB Status (Curr.)</td>
                     <td rowspan="2" style="font-size:.7em;padding: 1px">Sputum <br/>Collected</td>
                     <td rowspan="2" style="font-size:.7em;padding: 1px">Nutrition screening <br/>for normal MUAC</td>
@@ -68,8 +69,7 @@
                         <obsreference conceptId="$weight" id="weightInput" size="3"/>
                     </td>
                     <td>
-                        <obsreference conceptId="$pregBf" style="checkbox" answerLabel="Preg" answerConceptId="$cPreg" />
-                        <obsreference conceptId="$pregBf" style="checkbox" answerLabel="Bf" answerConceptId="$cLactating" />
+                        <obsreference conceptId="$bmi" id="bmiInput" size="3" allowOverride="True"/>
                     </td>
                     <td>
                         <obsreference conceptId="$tbStatus" style="radio" answerConceptId="$tbNotSuspected" answerLabel="No" />
@@ -155,14 +155,12 @@
                         <obsreference conceptId="$weight" id="weightInput" showUnits="true"/>
                     </td>
                 </tr>
-                <includeIf velocityTest="$patient.gender == 'F'">
-                    <tr>
-                        <th>Pregnant/Breastfeed.</th>
+                <tr>
+                    <th>MUAC/BMI</th>
                         <td>
-                            <obsreference id="pregnantBf" conceptId="$pregBf" style="checkbox" answerLabels="Preg,Bf" answerConceptIds="$cPreg,$cLactating"/>
+                            <obsreference conceptId="$bmi" id="bmiInput" size="3"/>
                         </td>
-                    </tr>
-                </includeIf>
+                </tr>
                 <tr>
                     <th>TB Status (Curr.)</th>
                     <td>


### PR DESCRIPTION
This PR does the following:

1. Updates the Likuni Phala field in the Adult Visit form to accept numeric values.
2. Adds a gender check as suggested [here](https://github.com/PIH/openmrs-module-pihmalawi/commit/83d99deb26160dc2227e54c3f1ded3f463c70391#r125971936)
3. Removes Preg/Breastfeeding and adds MUAC/BMI on Teen Club screening form.

@b-ngongonda @cioan PTAL