### PR TITLE
MLW-1640: replace HashMap with WeakHashMap

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihmalawi/data/IC3ScreeningDataLoader.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/data/IC3ScreeningDataLoader.java
@@ -50,7 +50,7 @@ public class IC3ScreeningDataLoader extends ScheduledExecutorFactoryBean {
     public IC3ScreeningDataLoader() {
         ScheduledExecutorTask task = new ScheduledExecutorTask();
         task.setDelay(10);
-        task.setPeriod(10); 
+        task.setPeriod(10);
         task.setTimeUnit(TimeUnit.MINUTES);
         task.setRunnable(new Runnable() {
             public void run() {

--- a/api/src/main/java/org/openmrs/module/pihmalawi/data/LivePatientDataSet.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/data/LivePatientDataSet.java
@@ -197,7 +197,7 @@ public abstract class LivePatientDataSet {
             getCache().updateCache(data, effectiveDate, location);
         }
         for (Integer pId : cohort.getMemberIds()) {
-            data.put(pId, cachedData.get(pId));
+            data.put(pId, getCache().getDataCache(effectiveDate, location).get(pId));
         }
 
         return data;


### PR DESCRIPTION
@mseaton , I think one of the main problems that could be the cause for this memory leak is that we use the HashMap data structure, which according to the docs and some other online references, is not eligible for garbage collector. The .clear(), and .remove() methods do not actually free up memory. Here are some references I found:

- https://docs.oracle.com/javase/8/docs/api/java/util/WeakHashMap.html
- https://stackoverflow.com/questions/61929041/application-memory-not-clearing-in-hashmap-by-remove-or-removeall-method
- https://www.geeksforgeeks.org/hashmap-vs-weakhashmap-java/

So, I just replaced the HashMap with WeakHashMap and also fixed a problem with key removal, so that all keys that are no longer used were removed. Happy to discuss this further, or step through the code together, in case you have other suggestions on how to address this memory leak. Thanks!
