### PR TITLE
MLW-1643: use child server MAC address for enhanced security

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihmalawi/PihMalawiConstants.java
+++ b/api/src/main/java/org/openmrs/module/pihmalawi/PihMalawiConstants.java
@@ -13,6 +13,9 @@ public class PihMalawiConstants {
     public static final String DASHBOARD_IDENTIFIERS_GP_NAME = "dashboard.identifiers";
     public static final String DASHBOARD_IDENTIFIERS_GP_VALUE = "{\"9\":[\"ARV Number\",\"HCC Number\",\"KS Number\",\"Chronic Care Number\",\"Palliative Care Number\",\"PDC Identifier\",\"Nutrition Program Number\",\"TB program identifier\"]}";
     public static final String PATIENT_IDENTIFIER_IMPORTANT_TYPES_GP_NAME = "patient_identifier.importantTypes";
+
+    public static final String SYNC_ALLOW_MAC_ADDRESSES_GP_NAME = "pihmalawi.syncAllowMacAddresses";
+
     public static final String PATIENT_IDENTIFIER_IMPORTANT_TYPES_GP_VALUE = "ARV Number,HCC Number,Chronic Care Number,Palliative Care Number,PDC Identifier,Nutrition Program Number,TB program identifier";
     public static final String TASK_CLOSE_STALE_VISITS_NAME = "PIH Malawi module - Close Stale Visits";
     public static final String TASK_CLOSE_STALE_VISITS_DESCRIPTION = "Closes any open visits that are no longer active";

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/RestUtils.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/RestUtils.java
@@ -1,5 +1,8 @@
 package org.openmrs.module.pihmalawi;
 
+import org.apache.commons.lang.StringUtils;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.sync.server.RemoteServer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -8,7 +11,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.openmrs.module.sync.server.RemoteServer;
 
 public class RestUtils {
 
@@ -37,5 +39,14 @@ public class RestUtils {
         }
         data.put("errorMessages",errorMessages);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(data);
+    }
+
+    public static boolean isMacAddressAllowed(String macAddress) {
+        boolean allowed = false;
+        if (StringUtils.isNotBlank(macAddress)) {
+            String addresses = Context.getAdministrationService().getGlobalProperty(PihMalawiConstants.SYNC_ALLOW_MAC_ADDRESSES_GP_NAME);
+            allowed = StringUtils.isNotBlank(addresses) && addresses.toLowerCase().contains(macAddress);
+        }
+        return allowed;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/RestUtils.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/RestUtils.java
@@ -45,7 +45,7 @@ public class RestUtils {
         boolean allowed = false;
         if (StringUtils.isNotBlank(macAddress)) {
             String addresses = Context.getAdministrationService().getGlobalProperty(PihMalawiConstants.SYNC_ALLOW_MAC_ADDRESSES_GP_NAME);
-            allowed = StringUtils.isNotBlank(addresses) && addresses.toLowerCase().contains(macAddress);
+            allowed = StringUtils.isNotBlank(addresses) && addresses.toLowerCase().contains(macAddress.toLowerCase());
         }
         return allowed;
     }

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/RestUtils.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/RestUtils.java
@@ -1,8 +1,8 @@
 package org.openmrs.module.pihmalawi;
 
 import org.apache.commons.lang.StringUtils;
-import org.openmrs.api.context.Context;
 import org.openmrs.module.sync.server.RemoteServer;
+import org.openmrs.util.ConfigUtil;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -41,11 +41,11 @@ public class RestUtils {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(data);
     }
 
-    public static boolean isMacAddressAllowed(String macAddress) {
+    public static boolean anyMacAddressesAllowed(List<String> macAddresses) {
         boolean allowed = false;
-        if (StringUtils.isNotBlank(macAddress)) {
-            String addresses = Context.getAdministrationService().getGlobalProperty(PihMalawiConstants.SYNC_ALLOW_MAC_ADDRESSES_GP_NAME);
-            allowed = StringUtils.isNotBlank(addresses) && addresses.toLowerCase().contains(macAddress.toLowerCase());
+        if (macAddresses != null && StringUtils.isNotBlank(macAddresses.get(0))) {
+            String addresses = ConfigUtil.getGlobalProperty(PihMalawiConstants.SYNC_ALLOW_MAC_ADDRESSES_GP_NAME);
+            allowed = StringUtils.isNotBlank(addresses) && addresses.toLowerCase().contains(macAddresses.get(0).toLowerCase());
         }
         return allowed;
     }

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/DownloadDbRestController.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/DownloadDbRestController.java
@@ -16,9 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 
 @RestController
 public class DownloadDbRestController {
@@ -27,10 +25,10 @@ public class DownloadDbRestController {
     private static String MANAGE_SYNC_PRIVILEGE = "Manage Synchronization";
 
     @GetMapping(value = "/rest/v1/pihmalawi/downloadDb")
-    public ResponseEntity<byte[]> getDbBackup(@RequestHeader HttpHeaders headers) throws IOException {
-        List<String> macAddress = headers.get("MAC-Address");
+    public ResponseEntity<byte[]> getDbBackup(@RequestHeader HttpHeaders headers) {
+
         try {
-            if ( macAddress !=null && RestUtils.isMacAddressAllowed(macAddress.get(0))) {
+            if ( RestUtils.anyMacAddressesAllowed(headers.get("MAC-Address"))) {
                 if (Context.hasPrivilege(MANAGE_SYNC_PRIVILEGE)) {
                     try {
                         File outputFile = Context.getService(SyncService.class).generateDataFile();

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/DownloadDbRestController.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/DownloadDbRestController.java
@@ -4,10 +4,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.pihmalawi.PublicKeyProvider;
 import org.openmrs.module.pihmalawi.RestUtils;
 import org.openmrs.module.sync.api.SyncService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,14 +26,11 @@ public class DownloadDbRestController {
 
     private static String MANAGE_SYNC_PRIVILEGE = "Manage Synchronization";
 
-    @Autowired
-    private PublicKeyProvider publicKeyProvider;
     @GetMapping(value = "/rest/v1/pihmalawi/downloadDb")
     public ResponseEntity<byte[]> getDbBackup(@RequestHeader HttpHeaders headers) throws IOException {
-        List<String> signature = headers.get("X-Signature");
-        List<String> signatureInput = headers.get("Signature-Input");
+        List<String> macAddress = headers.get("MAC-Address");
         try {
-            if (signatureInput != null && signature != null && publicKeyProvider.verifySignature(signatureInput.get(0), signature.get(0))) {
+            if ( macAddress !=null && RestUtils.isMacAddressAllowed(macAddress.get(0))) {
                 if (Context.hasPrivilege(MANAGE_SYNC_PRIVILEGE)) {
                     try {
                         File outputFile = Context.getService(SyncService.class).generateDataFile();

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/RegisterChildServerRestController.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/RegisterChildServerRestController.java
@@ -34,8 +34,7 @@ public class RegisterChildServerRestController {
     @ResponseBody
     public Object registerChildServer(@RequestBody String childServer, @RequestHeader HttpHeaders headers) {
         try {
-            List<String> macAddress = headers.get("MAC-Address");
-            if ( macAddress !=null && RestUtils.isMacAddressAllowed(macAddress.get(0))) {
+            if ( RestUtils.anyMacAddressesAllowed(headers.get("MAC-Address")) ) {
                 if (Context.hasPrivilege(MANAGE_SYNC_PRIVILEGE)) {
                     RemoteServer server = null;
                     ObjectMapper objectMapper = new ObjectMapper();

--- a/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/RegisterChildServerRestController.java
+++ b/omod/src/main/java/org/openmrs/module/pihmalawi/rest/controller/RegisterChildServerRestController.java
@@ -7,11 +7,9 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.pihmalawi.PublicKeyProvider;
 import org.openmrs.module.pihmalawi.RestUtils;
 import org.openmrs.module.sync.api.SyncService;
 import org.openmrs.module.sync.server.RemoteServer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,17 +28,14 @@ import java.util.List;
 public class RegisterChildServerRestController {
     protected Log log = LogFactory.getLog(getClass());
 
-    @Autowired
-    private PublicKeyProvider publicKeyProvider;
-
     private static String MANAGE_SYNC_PRIVILEGE = "Manage Synchronization";
 
     @RequestMapping(value = "/rest/v1/pihmalawi/registerChildServer", method = RequestMethod.POST)
     @ResponseBody
     public Object registerChildServer(@RequestBody String childServer, @RequestHeader HttpHeaders headers) {
         try {
-            List<String> signature = headers.get("X-Signature");
-            if ( signature !=null && publicKeyProvider.verifySignature(childServer, signature.get(0))) {
+            List<String> macAddress = headers.get("MAC-Address");
+            if ( macAddress !=null && RestUtils.isMacAddressAllowed(macAddress.get(0))) {
                 if (Context.hasPrivilege(MANAGE_SYNC_PRIVILEGE)) {
                     RemoteServer server = null;
                     ObjectMapper objectMapper = new ObjectMapper();
@@ -89,5 +84,4 @@ public class RegisterChildServerRestController {
             return RestUtils.errorResponse(e);
         }
     }
-
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -58,6 +58,12 @@
     </globalProperty>
 
     <globalProperty>
+        <property>pihmalawi.syncAllowMacAddresses</property>
+        <defaultValue></defaultValue>
+        <description>A comma delimited list of MAC addresses that are allowed to access the Sync REST API</description>
+    </globalProperty>
+
+    <globalProperty>
         <property>pihmalawi.showOldChronicCareCard</property>
         <defaultValue>true</defaultValue>
         <description>Indicates whether or not to enable the link to the previous version of the CCC Mastercard</description>


### PR DESCRIPTION
@mseaton , per our conversation yesterday I have switched the extra authentication step to use the MAC address of the client. 